### PR TITLE
Setup admin

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,10 @@ import Register from "./pages/Register/Register";
 import Account from "./pages/Account/Account";
 import UpdateProfile from "./pages/UpdateProfile/UpdateProfile";
 import { PrivateRoute } from "./components/PrivateRoute/PrivateRoute";
+import AdminDashboard from "./pages/AdminDashboard/AdminDashboard";
 
 const App = () => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isAdmin } = useAuth();
 
   return (
     <>
@@ -23,12 +24,20 @@ const App = () => {
         <Routes>
           {isAuthenticated ? (
             <Route path="/" element={<PrivateRoute />}>
-              <Route path="/" element={<Home />} />
-              <Route path="/tasks" element={<ActiveTasks />} />
-              <Route path="/calendar" element={<Calendar />} />
-              <Route path="/leaderboard" element={<Leaderboard />} />
-              <Route path="/profile" element={<Profile />} />
-              <Route path="/edit" element={<UpdateProfile />} />
+              {isAdmin ? (
+                <>
+                  <Route path="/" element={<AdminDashboard />} />
+                </>
+              ) : (
+                <>
+                  <Route path="/" element={<Home />} />
+                  <Route path="/tasks" element={<ActiveTasks />} />
+                  <Route path="/calendar" element={<Calendar />} />
+                  <Route path="/leaderboard" element={<Leaderboard />} />
+                  <Route path="/profile" element={<Profile />} />
+                  <Route path="/edit" element={<UpdateProfile />} />
+                </>
+              )}
             </Route>
           ) : (
             <>

--- a/src/pages/AdminDashboard/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard/AdminDashboard.tsx
@@ -1,8 +1,16 @@
+import Button from "../../components/Button/Button";
+import { useAuth } from "../../hooks/useAuth";
+
 const AdminDashboard = () => {
+  const { logoutUser } = useAuth();
+
   return (
     <div>
       <h1>Admin Dashboard</h1>
-      <p>This is the admin dashboard. This area is under construction.</p>
+      <p>This is the admin dashboard</p>
+      <div>
+        <Button label={"SIGN OUT"} variant={"secondary"} onClick={logoutUser} />
+      </div>
     </div>
   );
 };

--- a/src/pages/AdminDashboard/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard/AdminDashboard.tsx
@@ -1,0 +1,10 @@
+const AdminDashboard = () => {
+  return (
+    <div>
+      <h1>Admin Dashboard</h1>
+      <p>This is the admin dashboard. This area is under construction.</p>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/utils/dbUtils.ts
+++ b/src/utils/dbUtils.ts
@@ -16,6 +16,7 @@ export enum FirestoreCollections {
   ACTIVE_TASKS = "test-active-tasks",
   COMPLETED_TASKS = "test-completed-tasks",
   TRIBE = "test-tribe",
+  ADMIN = "admin",
 }
 
 /**

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -74,11 +74,12 @@ const wrapWithRouting = (ui: JSX.Element): JSX.Element => {
 type AuthProviderOptions = {
   isAuthenticated?: boolean;
   user: UserProfile | UserLoading;
+  isAdmin?: boolean;
 };
 
 const wrapWithAuthProvider = (
   ui: JSX.Element,
-  { isAuthenticated, user }: AuthProviderOptions
+  { isAuthenticated, user, isAdmin }: AuthProviderOptions
 ): JSX.Element => {
   const defaultAuthContext: AuthContextProps = {
     createUser: (_, __) => Promise.resolve({ error: null }),
@@ -86,6 +87,7 @@ const wrapWithAuthProvider = (
     loginUser: (_, __) => Promise.resolve({ error: null }),
     logoutUser: () => null,
     isAuthenticated: isAuthenticated ?? false,
+    isAdmin: isAdmin ?? false,
     getUser: () => user,
   };
 


### PR DESCRIPTION
We have implemented the admin within a collection on FireBase with a generic email admin@admin.com. We have then updated the ENUM for FireStoreCollections to include our new admin collection. AuthProvider was then updated in similar manner to isAuthenticated with a new state isAdmin to determine whether the user ID is within the admin collection. The app routing is then updated to check if they are an admin following checking if they are authenticated, if they are they are routed to a placeholder page called AdminDashboard